### PR TITLE
Add config option to specify input device index

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,6 +4,9 @@
 
 [stream]
 
+# Input device (-1 means "use default device")
+INPUT_DEVICE = -1
+
 # Read chunk size
 CHUNK = 512
 

--- a/config/default.ini
+++ b/config/default.ini
@@ -5,7 +5,7 @@
 [stream]
 
 # Input device (-1 means "use default device")
-INPUT_DEVICE = -1
+INPUT_DEVICE = 11
 
 # Read chunk size
 CHUNK = 512

--- a/sopare/audio_factory.py
+++ b/sopare/audio_factory.py
@@ -31,7 +31,11 @@ class audio_factory():
         self.debug_once = False
 
     def open(self, sample_rate, input_format=pyaudio.paInt16):
-        device = self.cfg.getintoption('stream', 'INPUT_DEVICE')
+        try:
+            device = self.cfg.getintoption('stream', 'INPUT_DEVICE')
+        except ValueError:     # user put text there
+            raise Exception('Could not parse value for INPUT_DEVICE in config.'
+                            ' Expected a device number (int) or -1')
         if device == -1:
             device = None
         if (self.debug_once == False):
@@ -49,7 +53,11 @@ class audio_factory():
                 device_info = self.pa.get_default_input_device_info()
             else:
                 self.logger.debug('Using device ' + str(device))
-                device_info = self.pa.get_device_info_by_index(device)
+                try:
+                    device_info = self.pa.get_device_info_by_index(device)
+                except IOError as ioe:
+                    raise Exception('Could not open device number {0}: {1}'
+                                    .format(device, ioe))
             for k, v in device_info.iteritems():
                 self.logger.debug(str(k) + ': ' + str(v))
             self.debug_once = True


### PR DESCRIPTION
I struggle with setting a default device using ALSA, other people might do so, too. Also,
users might not be able to adjust the default device because other applications require a
different default device.

Therefore offer an option to specify input device index in config. This is a rather small
change but helped me a lot.

Problem (future work): device indices are rather variable, they change if somebody plugs or
unplugs a sound device, for example.